### PR TITLE
Eldo

### DIFF
--- a/src/api/v1/metrics.py
+++ b/src/api/v1/metrics.py
@@ -100,12 +100,14 @@ def brand_position(
 # Brand Ranking
 @router.get("/ranking")
 def brand_ranking(
+    brand_report_id = "",
     start_date: str = "",
     end_date: str = "",
     model: str = "all"
 ):
     try:
         result = clickhouse.get_brand_ranking(
+            brand_report_id=brand_report_id,
             start_date=start_date,
             end_date=end_date,
             model=model


### PR DESCRIPTION
Enhance ClickHouse brand metrics: add filters for position and ranking

Description :
This PR updates the ClickHouse class to improve flexibility for brand metrics queries by adding optional filtering parameters for get_brand_position and get_brand_ranking.

Changes included:

get_brand_position

Added optional parameters: brand_report_id, start_date, end_date, and model.

Computes the brand's position relative to the filtered sample.

Builds dynamic SQL WHERE clause based on provided filters.

get_brand_ranking

Added optional parameters: brand_report_id, start_date, end_date, and model.

Dynamically filters data based on the arguments.

Returns ranking of brands by total mentions with proper handling of ties.

Updated FastAPI endpoints to pass new arguments for ranking and position metrics.