### PR TITLE
Ajout endpoint get_outputs et fonction get_output_report

### DIFF
--- a/src/api/v1/prompts.py
+++ b/src/api/v1/prompts.py
@@ -1,17 +1,34 @@
-from fastapi import APIRouter, HTTPException
-
+from fastapi import APIRouter, HTTPException, Query
+from src.infrastructure.database import DataBase
+from src.infrastructure.aws_storage import get_presigned_url  # fonction pour générer l'URL S3
 
 router = APIRouter(
-    prefix="/report/prompts", responses={404: {"description": "Not found"}}
+    prefix="/report/prompts",
+    responses={404: {"description": "Not found"}}
 )
 
+# Instance de la base de données
+db = DataBase()
 
 @router.get("/outputs")
-def get_outputs() -> dict:
-    output = {"snapshot_url": "", "markdown": ""}
-    return {"details": output}
+def get_outputs(
+    brand_report_id: str = Query(..., description="ID du rapport de la marque"),
+    date: str = Query(..., description="Date du rapport au format YYYY-MM-DD"),
+    model: str = Query(..., description="Nom du modèle")
+) -> dict:
+    """
+    Récupère le snapshot et le markdown d'un rapport.
+    Retourne l'URL complète du snapshot via AWS S3.
+    """
+    # Récupérer snapshot et markdown depuis la base
+    report = db.get_output_report(brand_report_id, date, model)
+    if not report:
+        raise HTTPException(status_code=404, detail="Output report not found")
 
+    # Générer l'URL complète du snapshot
+    snapshot_url = get_presigned_url(report["snapshot"])
 
-# @router.get("/citation")
-
-# @router.get("/sentiment")
+    return {
+        "snapshot_url": snapshot_url,
+        "markdown": report["markdown"]
+    }

--- a/src/infrastructure/database.py
+++ b/src/infrastructure/database.py
@@ -1,4 +1,4 @@
-from sqlmodel import Session, create_engine
+from sqlmodel import Session, create_engine, select
 from src.infrastructure.models import Output_Reports, SQLModel, Citations, Sentiments
 from src.config import config
 
@@ -29,3 +29,21 @@ class DataBase:
         with Session(self.engine) as session:
             session.add(output_report)
             session.commit()
+    
+    def get_output_report(self, brand_report_id: str, date: str, model: str) -> None:
+        with Session(self.engine) as session:
+            statement = (
+                select(Output_Reports)
+                .where(Output_Reports.brand_report_id == brand_report_id)
+                .where(Output_Reports.date == date)
+                .where(Output_Reports.model == model)
+            )
+            result = session.exec(statement).first()
+
+            if not result:
+                return None
+
+            return {
+                "snapshot": result.snapshot,
+                "markdown": result.markdown
+            }


### PR DESCRIPTION
- Ajoute la route GET /report/prompts/outputs
  avec params : brand_report_id, date, model
- Retourne snapshot_url et markdown
- get_output_report récupère les données depuis la table output_reports
- get_presigned_url est utilisé pour fournir l’URL complète du snapshot
- Retourne None si aucune donnée correspondante