### PR TITLE
Définition de la fonction get_sentiments et création de l'endpoint /s…

### DIFF
--- a/src/infrastructure/database.py
+++ b/src/infrastructure/database.py
@@ -69,3 +69,20 @@ class DataBase:
         # Transformer en dict
         citations = [r.dict() for r in results]  # SQLModel fournit .dict()
         return citations
+
+    def get_sentiments(self, brand_report_id: str, date: str, model: str = "all") -> list[dict]:
+        """
+        Récupère les sentiments depuis la table Sentiments avec filtres optionnels.
+        """
+        with Session(self.engine) as session:
+            statement = select(Sentiments).where(
+                Sentiments.brand_report_id == brand_report_id,
+                Sentiments.date == date
+            )
+
+            if model.lower() != "all":
+                statement = statement.where(Sentiments.model == model)
+
+            results = session.exec(statement).all()
+        sentiments = [r.dict() for r in results]
+        return sentiments


### PR DESCRIPTION
Description :
Ce PR apporte les modifications suivantes :

Définition de la fonction get_sentiments dans database.py

Permet de récupérer les sentiments pour un brand_report_id et une date donnés.

Ajout du filtre optionnel model (appliqué uniquement si différent de "all").

Retourne les sentiments sous forme de dictionnaire.

Création de l’endpoint /sentiments dans prompts.py

Permet d’exposer les données de sentiments via l’API.

Les arguments nécessaires (brand_report_id, date, model) sont pris via Depends.

Ajout de count_positive_phrases et count_negative_phrases

Compte automatiquement le nombre de phrases positives et négatives pour chaque sentiment.

Ces valeurs sont retournées avec le reste des données pour chaque sentiment.